### PR TITLE
Fix: Applied Base setting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import image from '@astrojs/image';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'http://www.site.com/grandparent/parent/root/',
+  site: 'http://www.site.com/',
+  base:'grandparent/parent/root/',
   integrations: [image()],
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,4 @@
 import { defineConfig } from 'astro/config';
-
 import image from '@astrojs/image';
 
 // https://astro.build/config


### PR DESCRIPTION
Ammended the `astro.config` to include the `base` setting, this is where you specify the base path that you are deploying to. 
This fixes the CSS being loaded as the URLs are properly referenced,

The Bug that has been identified is with the Image component not recognizing this. Will flag for Investigation `withastro`